### PR TITLE
Security: upgrade Jackson & build tooling; set Java 8 baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
-                        <version>2.3.2</version>
+                        <version>3.1.1</version>
                         <configuration>
                             <mavenExecutorId>forked-path</mavenExecutorId>
                         </configuration>
@@ -80,22 +80,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.3.1</version>
+            <version>2.19.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.1</version>
+            <version>2.19.2</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
+            <version>1.19.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -105,10 +105,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <fork>true</fork>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description
Refresh outdated dependencies and modernize the build to address security and maintenance concerns. Key changes: move off very old Jackson releases and set a Java 8 baseline.

### Changes
- **Jackson**
  - `com.fasterxml.jackson.core:jackson-core` **2.3.1 → 2.19.2**
  - `com.fasterxml.jackson.core:jackson-databind` **2.3.1 → 2.19.2**
- **Commons Codec**
  - `commons-codec:commons-codec` **1.6 → 1.19.0**
- **JUnit (test scope)**
  - `junit:junit` **4.11 → 4.13.2**
- **Build plugins**
  - `maven-release-plugin` **2.3.2 → 3.1.1**
  - `maven-compiler-plugin` **2.5.1 → 3.13.0**
- **Java level**
  - `maven-compiler-plugin` `source`/`target` **1.5 → 1.8**

